### PR TITLE
Allow uninitialized slices to work.

### DIFF
--- a/lib/String/Slice.pm
+++ b/lib/String/Slice.pm
@@ -68,6 +68,9 @@ int slice (SV* dummy, ...) {
       // Set the slice pointer.
       SvPV_set(slice, slice_ptr);
 
+      // Let it know it's an SvPV (if it doesn't already)
+      SvPOK_on(slice);
+
       // Calculate the proper byte length for the utf8 slice
 
       // If requested number of chars is negative (default) or too big,

--- a/test/test.t
+++ b/test/test.t
@@ -38,4 +38,10 @@ is $slice, 'Net', 'Advance matches text';
 $return = slice($slice, $string2, -100);
 is $return, 0, 'Hop too far back fails';
 
+# Don't have to initialize slice to a string
+my $other_slice;
+$return = slice($other_slice, $string, 1, 10);
+is $return, 1, 'Slicing to an uninitialized slice works';
+is($other_slice, ('x' x 10), 'Slice matches text');
+
 done_testing;


### PR DESCRIPTION
Previously, this failed since POK wasn't set for $slice:

  my $slice;
  slice($slice, $buffer, 1, 5); # $slice would appear undef
